### PR TITLE
feat(dto): enrich MentorDTO and ClassRoomDTO with nested entity support

### DIFF
--- a/src/main/java/com/skillmentor/root/dto/ClassRoomDTO.java
+++ b/src/main/java/com/skillmentor/root/dto/ClassRoomDTO.java
@@ -9,6 +9,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -23,7 +25,12 @@ public class ClassRoomDTO {
     @NotNull(message = "Enrolled student count must not be null")
     @JsonProperty("enrolled_student_count")
     private Integer enrolledStudentCount;
-    @JsonProperty("mentor")
+    @JsonProperty(value = "mentor", access = JsonProperty.Access.READ_ONLY)
     private MentorDTO mentorDTO;
+    @NotNull(message = "MentorId must not be null")
+    @JsonProperty(value = "mentor_id", access = JsonProperty.Access.WRITE_ONLY)
+    private Integer mentorId;
+    @JsonProperty(value = "session", access = JsonProperty.Access.READ_ONLY)
+    private List<SessionDTO> sessionDTOList;
 
 }

--- a/src/main/java/com/skillmentor/root/dto/MentorDTO.java
+++ b/src/main/java/com/skillmentor/root/dto/MentorDTO.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -49,7 +51,9 @@ public class MentorDTO{
     @NotBlank(message = "Qualification must not be blank")
     @JsonProperty("qualification")
     private String qualification;
-    @NotNull(message = "Classroom ID must not be null")
-    @JsonProperty("class_room_id")
-    private Integer classRoomId;
+    @JsonProperty(value = "class_room", access = JsonProperty.Access.READ_ONLY)
+    private ClassRoomDTO classRoomDTO;
+    @JsonProperty(value = "session", access = JsonProperty.Access.READ_ONLY)
+    private List<SessionDTO> sessionDTO;
+
 }

--- a/src/main/java/com/skillmentor/root/entity/ClassRoomEntity.java
+++ b/src/main/java/com/skillmentor/root/entity/ClassRoomEntity.java
@@ -1,5 +1,6 @@
 package com.skillmentor.root.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -37,5 +38,6 @@ public class ClassRoomEntity {
     private MentorEntity mentor;
     @OneToMany(mappedBy = "classRoomEntity", fetch = FetchType.EAGER)
     @Schema(description = "List of sessions associated with this classroom")
+    @JsonManagedReference
     private List<SessionEntity> sessionEntityList = new ArrayList<>();
 }


### PR DESCRIPTION
### Summary
Enhanced the data transfer objects for both Mentor and ClassRoom to support better request/response structuring and nested data relationships.

### Changes
- **ClassRoomDTO**
  - Added `mentorId` as a write-only field to handle mentor assignment during creation.
  - Added `sessionDTOList` as a read-only field to include session data in API responses.
  - Set `mentorDTO` to read-only to control serialization flow.

- **MentorDTO**
  - Replaced the writable `classRoomId` with a read-only `classRoomDTO` for improved representation.
  - Added `sessionDTO` list to expose mentor's session information in API responses.

### Benefits
- Improves API flexibility and clarity by separating input (write) and output (read) concerns.
- Enhances front-end usability by including related nested data directly in the DTOs.
